### PR TITLE
Added convenient copy operation.

### DIFF
--- a/include/mapped_soa.h
+++ b/include/mapped_soa.h
@@ -85,6 +85,10 @@ class MappedSoA {
     key_to_index_.erase(key);
   }
 
+  void copy(size_t index_from, size_t index_to) {
+    soa_.copy(index_from, index_to);
+  }
+
   void swap(size_t index0, size_t index1) {
     const size_t size_val = size();
     if (size_val <= index0 || size_val <= index1) {

--- a/include/soa.h
+++ b/include/soa.h
@@ -147,6 +147,23 @@ class SoA {
     size_ -= num_elements;
   }
 
+  // Copies an element into another element inside the array.
+  void copy(size_t index_from, size_t index_to) {
+    if (index_from >= size() || index_to >= size()) {
+      assert(false);
+
+      return;
+    }
+
+    if (index_from == index_to) {
+      return;
+    }
+
+    size_t array_index = 0;
+    int dummy[] = {(copy_impl<Elements>(index_from, index_to, array_index++), 0)...};
+    (void)dummy;
+  }
+
   // Swaps two elements inside the array.
   void swap(size_t index0, size_t index1) {
     if (index0 >= size() || index1 >= size()) {
@@ -262,6 +279,13 @@ class SoA {
 
     array->erase(array->begin() + element_index,
                  array->begin() + element_index + num_elements);
+  }
+
+  template <class Type>
+  void copy_impl(size_t index_from, size_t index_to, size_t array_index) {
+    std::vector<Type>* array = get_array<Type>(array_index);
+
+    (*array)[index_to] = (*array)[index_from];
   }
 
   template <class Type>


### PR DESCRIPTION
This change allows us to do a full copy of every fields of an array index without needing the knowledge of those fields.  Example:
```C++
Dog &Dog::operator=(const Dog &other)
{
    if (this != &other)
    {
        _data.copy(other._idx, _idx);
    }
    return *this;
}
```
resolves #8